### PR TITLE
chore(ci): add AI Readiness Scorecard caller (R07)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,15 @@
+name: AI Readiness Scorecard
+
+on:
+  push:
+    branches: [v0.5.x]
+  workflow_dispatch:
+
+jobs:
+  scorecard:
+    uses: torre-labs/workflows/.github/workflows/scorecard.yml@v4
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      workflows-ref: v4   # must match the @ref above; see torre-labs/workflows README "Versioning"


### PR DESCRIPTION
Enrolls this repo in the centralized **AI Readiness Scorecard** reusable workflow (`torre-labs/workflows/.github/workflows/scorecard.yml@v4`) — part of the agentic-dev-plan **R07** fleet-wide rollout.

- Re-scores agent-readiness **0–100** across eighteen repo-resident dimensions on every push to the default branch (plus manual `workflow_dispatch`).
- **Advisory only** — it uploads a `scorecard.json` artifact + a job-summary table and **never gates a merge**.
- Reuses the existing org `AI_REVIEW_BOT` GitHub App + Actions access; **no new secrets**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
